### PR TITLE
Fix typographical error(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1608,7 +1608,7 @@ var immutableState = Object.freeze({
 
 [EXPLICAR]
 
-Mas o que é um efeito colateral (*side effect*)? Um pedaço de código segundo o qual uma variável é criada e está disponível ao longo de uma extensão quando ele não precisa de ser. Deixe-me mostrar-lhe alguns exemplos e como evitar esses efeitos colaterais indesejados:
+Mas o que é um efeito collateral (*side effect*)? Um pedaço de código segundo o qual uma variável é criada e está disponível ao longo de uma extensão quando ele não precisa de ser. Deixe-me mostrar-lhe alguns exemplos e como evitar esses efeitos colaterais indesejados:
 
 >Array.prototype.forEach() instead of for(var x = ...)
 
@@ -1624,7 +1624,7 @@ for(var x=0, length = myArray.length; x < length; x++) {
 // "x" and "length" são efeitos colaterais
 ```
 
-O efeito colateral deste padrão é, no mínimo, o índice incremental `x`, se não o `length`, elas estão disponíveis em todo o escopo. Métodos do *prototype* do *Array* como map, foreach, e outros nos evitam esses efeitos colaterais:
+O efeito collateral deste padrão é, no mínimo, o índice incremental `x`, se não o `length`, elas estão disponíveis em todo o escopo. Métodos do *prototype* do *Array* como map, foreach, e outros nos evitam esses efeitos colaterais:
 
 ```js
 [1, 2, 3].forEach(function(item, index, array) {


### PR DESCRIPTION
@Webschool-io, I've corrected a typographical error in the documentation of the [workshop-js-funcional-free](https://github.com/Webschool-io/workshop-js-funcional-free) project. Specifically, I've changed colateral to collateral. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
